### PR TITLE
Various enhancements and bug fixes. See description

### DIFF
--- a/firmware/include/functions/fw_settings.h
+++ b/firmware/include/functions/fw_settings.h
@@ -43,6 +43,7 @@ typedef struct settingsStruct
 	struct_codeplugChannel_t vfoChannel;
 	uint32_t		overrideTG;
 	uint8_t			useCalibration;
+	uint8_t			squelch;
 } settingsStruct_t;
 
 extern settingsStruct_t nonVolatileSettings;

--- a/firmware/include/interfaces/fw_adc.h
+++ b/firmware/include/interfaces/fw_adc.h
@@ -24,8 +24,9 @@
 
 #include "fsl_adc16.h"
 
-#define CUTOFF_VOLTAGE_UPPER_HYST 64
-#define CUTOFF_VOLTAGE_LOWER_HYST 62
+extern const int CUTOFF_VOLTAGE_UPPER_HYST;
+extern const int CUTOFF_VOLTAGE_LOWER_HYST;
+extern const int BATTERY_MAX_VOLTAGE;
 
 extern volatile uint32_t adc_channel;
 extern volatile uint32_t adc0_dp0;

--- a/firmware/source/functions/fw_settings.c
+++ b/firmware/source/functions/fw_settings.c
@@ -30,7 +30,7 @@ const int BAND_UHF_MAX 	= 4500000;
 
 static const int STORAGE_BASE_ADDRESS 		= 0x6000;
 static const int STORAGE_BASE_ADDRESS_OLD 	= 0xFF00;
-static const int STORAGE_MAGIC_NUMBER 		= 0x471B;
+static const int STORAGE_MAGIC_NUMBER 		= 0x471C;
 
 settingsStruct_t nonVolatileSettings;
 struct_codeplugChannel_t *currentChannelData;
@@ -113,6 +113,7 @@ void settingsRestoreDefaultSettings()
 	nonVolatileSettings.txPower=1600;// intialized to about original firmware LOW
 	nonVolatileSettings.overrideTG=0;// 0 = No override
 	nonVolatileSettings.useCalibration = 0x01;// enable the new calibration system
+	nonVolatileSettings.squelch = 45;// default reasonable value for FM
 	initVFOChannel();
 	currentChannelData = &nonVolatileSettings.vfoChannel;// Set the current channel data to point to the VFO data since the default screen will be the VFO
 

--- a/firmware/source/functions/fw_trx.c
+++ b/firmware/source/functions/fw_trx.c
@@ -42,7 +42,6 @@ static bool currentBandWidth = BANDWIDTH_12P5KHZ;
 static int currentFrequency =1440000;
 static int currentCC =1;
 static uint8_t squelch = 0x00;
-static const uint8_t SQUELCH_SETTINGS[] = {45,45,45};
 static bool rxCTCSSactive = false;
 
 int	trxGetMode()
@@ -100,7 +99,7 @@ void trx_check_analog_squelch()
 		uint8_t RX_noise;
 		read_I2C_reg_2byte(I2C_MASTER_SLAVE_ADDR_7BIT, 0x1b,&RX_signal,&RX_noise);
 
-		if ((RX_noise < SQUELCH_SETTINGS[0]) || (open_squelch))
+		if ((RX_noise < nonVolatileSettings.squelch) || (open_squelch))
 		{
 			GPIO_PinWrite(GPIO_LEDgreen, Pin_LEDgreen, 1);
 			if(!rxCTCSSactive || (rxCTCSSactive & trxCheckCTCSSFlag())|| open_squelch)

--- a/firmware/source/interfaces/fw_adc.c
+++ b/firmware/source/interfaces/fw_adc.c
@@ -24,6 +24,10 @@ volatile uint32_t adc0_dp1;
 volatile uint32_t adc0_dp2;
 volatile uint32_t adc0_dp3;
 
+const int CUTOFF_VOLTAGE_UPPER_HYST = 64;
+const int CUTOFF_VOLTAGE_LOWER_HYST = 62;
+const int BATTERY_MAX_VOLTAGE = 83;
+
 void trigger_adc()
 {
     adc16_channel_config_t adc16ChannelConfigStruct;

--- a/firmware/source/menu/menuBattery.c
+++ b/firmware/source/menu/menuBattery.c
@@ -45,8 +45,7 @@ int menuBattery(int buttons, int keys, int events, bool isFirstRun)
 
 static void updateScreen()
 {
-	const int BATTERY_MIN_VOLTAGE = 7;
-	const float BATTERY_MAX_VOLTAGE = 8.4;
+	const int MAX_BATTERY_BAR_HEIGHT = 50;
 	char buffer[8];
 
 	UC1701_clearBuf();
@@ -57,11 +56,11 @@ static void updateScreen()
 
 	sprintf(buffer,"%d.%dV", val1,val2);
 	UC1701_printAt(24,16, buffer,UC1701_FONT_16x32);
-	uint32_t h = (uint32_t)(((battery_voltage - BATTERY_MIN_VOLTAGE) * 50)/(BATTERY_MAX_VOLTAGE-BATTERY_MIN_VOLTAGE));
+	uint32_t h = (uint32_t)(((battery_voltage - CUTOFF_VOLTAGE_UPPER_HYST) * MAX_BATTERY_BAR_HEIGHT) / (BATTERY_MAX_VOLTAGE - CUTOFF_VOLTAGE_UPPER_HYST));
 
-	if (h>50)
+	if (h>MAX_BATTERY_BAR_HEIGHT)
 	{
-		h=50;
+		h=MAX_BATTERY_BAR_HEIGHT;
 	}
 	// draw frame
 	UC1701_fillRect(100,10,24,52,false);

--- a/firmware/source/menu/menuChannelMode.c
+++ b/firmware/source/menu/menuChannelMode.c
@@ -209,10 +209,12 @@ static void handleEvent(int buttons, int keys, int events)
 	{
 		if (trxGetMode() == RADIO_MODE_ANALOG)
 		{
+			channelScreenChannelData.chMode = RADIO_MODE_DIGITAL;
 			trxSetMode(RADIO_MODE_DIGITAL);
 		}
 		else
 		{
+			channelScreenChannelData.chMode = RADIO_MODE_ANALOG;
 			trxSetMode(RADIO_MODE_ANALOG);
 			trxSetTxCTCSS(currentChannelData->rxTone);
 		}

--- a/firmware/source/menu/menuUtilityQSOData.c
+++ b/firmware/source/menu/menuUtilityQSOData.c
@@ -351,4 +351,15 @@ void menuUtilityRenderHeader()
 	}
 
 	UC1701_printAt(0,8, buffer,UC1701_FONT_6X8);
+	int  batteryPerentage = (int)(((battery_voltage - CUTOFF_VOLTAGE_UPPER_HYST) * 100) / (BATTERY_MAX_VOLTAGE - CUTOFF_VOLTAGE_UPPER_HYST));
+	if (batteryPerentage>100)
+	{
+		batteryPerentage=100;
+	}
+	if (batteryPerentage<0)
+	{
+		batteryPerentage=0;
+	}
+	sprintf(buffer,"%d%%",batteryPerentage);
+	UC1701_printCore(0,8,buffer,UC1701_FONT_6X8,2,false);// Display battery percentage at the right
 }

--- a/firmware/source/menu/menuVFOMode.c
+++ b/firmware/source/menu/menuVFOMode.c
@@ -267,10 +267,12 @@ static void handleEvent(int buttons, int keys, int events)
 		{
 			if (trxGetMode() == RADIO_MODE_ANALOG)
 			{
+				channelScreenChannelData.chMode = RADIO_MODE_DIGITAL;
 				trxSetMode(RADIO_MODE_DIGITAL);
 			}
 			else
 			{
+				channelScreenChannelData.chMode = RADIO_MODE_ANALOG;
 				trxSetMode(RADIO_MODE_ANALOG);
 				trxSetTxCTCSS(currentChannelData->rxTone);
 			}


### PR DESCRIPTION
At the request of several testers I've added the battery percentage display to the top right of the VFO and Channel screens. I had to make some changes to other files to centralize the constants.

I also added "squelch" to the nonVolatileSettings in preparation to adding variable squelch control when in FM mode

Also fixed bug when on the VFO or Channel screen the mode had been manually changed using the star button, the mode would when the screen was next loaded, e..g. the next time the radio went from Tx to Rx.