### PR TITLE
Multiple bug fixes

### DIFF
--- a/firmware/include/functions/fw_sound.h
+++ b/firmware/include/functions/fw_sound.h
@@ -44,6 +44,7 @@ extern const int melody_orange_beep[];
 extern const int melody_ACK_beep[];
 extern const int melody_NACK_beep[];
 extern const int melody_ERROR_beep[];
+extern const int melody_tx_timeout_beep[];
 extern volatile int *melody_play;
 extern volatile int melody_idx;
 

--- a/firmware/source/chips/fw_AT1846S.c
+++ b/firmware/source/chips/fw_AT1846S.c
@@ -95,7 +95,6 @@ const uint8_t AT1846FM12P5kHzSettings[][AT1846_BYTES_PER_COMMAND] = {
 		{0x0F, 0x3F, 0x44}, // AGC Table (recommended value for 12.5kHz bandwidth operation)
 		{0x12, 0xE0, 0xEB}, // AGC Table (recommended value for 12.5kHz bandwidth operation)
 		{0x7F, 0x00, 0x00}, // Go back to page 0 registers
-		{0x30, 0x40, 0x26}, // filter_band_sel + band_mode_sel = 12.5KHz
 		};
 
 const uint8_t AT1846FM25kHzSettings[][AT1846_BYTES_PER_COMMAND] = {
@@ -121,7 +120,6 @@ const uint8_t AT1846FM25kHzSettings[][AT1846_BYTES_PER_COMMAND] = {
 		{0x0F, 0x3F, 0x84}, // AGC Table (recommended value for 25kHz bandwidth operation)
 		{0x12, 0xE0, 0xEB}, // AGC Table (recommended value for 25kHz bandwidth operation)
 		{0x7F, 0x00, 0x00}, // Go back to page 0 registers
-		{0x30, 0x70, 0x26}, // filter_band_sel + band_mode_sel = 25kHz
 		};
 
 const uint8_t AT1846FMSettings[][AT1846_BYTES_PER_COMMAND] = {
@@ -186,11 +184,15 @@ void I2C_AT1846_SetBandwidth()
 	{
 		// 25 kHz settings
 		I2C_AT1846S_send_Settings(AT1846FM25kHzSettings,sizeof(AT1846FM25kHzSettings)/AT1846_BYTES_PER_COMMAND);
+		set_clear_I2C_reg_2byte_with_mask(0x30,0xCF,0x9F,0x30,0x00); // Set the 25Khz Bits and turn off the Rx and Tx
+		set_clear_I2C_reg_2byte_with_mask(0x30,0xFF,0x9F,0x00,0x20); // Turn the Rx On
 	}
 	else
 	{
 		// 12.5 kHz settings
 		I2C_AT1846S_send_Settings(AT1846FM12P5kHzSettings, sizeof(AT1846FM12P5kHzSettings)/AT1846_BYTES_PER_COMMAND);
+		set_clear_I2C_reg_2byte_with_mask(0x30,0xCF,0x9F,0x00,0x00); // Clear the 25Khz Bits and turn off the Rx and Tx
+		set_clear_I2C_reg_2byte_with_mask(0x30,0xFF,0x9F,0x00,0x20); // Turn the Rx On
 	}
 }
 

--- a/firmware/source/functions/fw_codeplug.c
+++ b/firmware/source/functions/fw_codeplug.c
@@ -42,6 +42,8 @@ const int CODEPLUG_ADDR_BOOT_LINE1 = 0x7540;
 const int CODEPLUG_ADDR_BOOT_LINE2 = 0x7550;
 const int CODEPLUG_ADDR_VFO_A_CHANNEL = 0x7590;
 
+const int MAX_CHANNELS_PER_ZONE = 16;
+
 uint32_t byteSwap32(uint32_t n)
 {
     return ((((n)&0x000000FFU) << 24U) | (((n)&0x0000FF00U) << 8U) | (((n)&0x00FF0000U) >> 8U) | (((n)&0xFF000000U) >> 24U));// from usb_misc.h
@@ -92,7 +94,7 @@ void codeplugZoneGetDataForIndex(int index,struct_codeplugZone_t *returnBuf)
 {
 	// IMPORTANT. read size is different from the size of the data, because I added a extra property to the struct to hold the number of channels in the zone.
 	EEPROM_Read(CODEPLUG_ADDR_EX_ZONE_LIST + (index * CODEPLUG_ZONE_DATA_SIZE), (uint8_t*)returnBuf, sizeof(struct_codeplugZone_t));
-	for(int i=0;i<32;i++)
+	for(int i=0;i<MAX_CHANNELS_PER_ZONE;i++)
 	{
 		// Empty channels seem to be filled with zeros
 		if (returnBuf->channels[i] == 0)
@@ -101,7 +103,7 @@ void codeplugZoneGetDataForIndex(int index,struct_codeplugZone_t *returnBuf)
 			return;
 		}
 	}
-	returnBuf->NOT_IN_MEMORY_numChannelsInZone=32;
+	returnBuf->NOT_IN_MEMORY_numChannelsInZone=MAX_CHANNELS_PER_ZONE;
 }
 
 void codeplugChannelGetDataForIndex(int index, struct_codeplugChannel_t *channelBuf)

--- a/firmware/source/functions/fw_sound.c
+++ b/firmware/source/functions/fw_sound.c
@@ -45,6 +45,7 @@ const int melody_orange_beep[] = { 440, 60, 494, 60, 440, 60, 494, 60, -1, -1 };
 const int melody_ACK_beep[] = { 440, 120, 660, 120, 880, 120, -1, -1 };
 const int melody_NACK_beep[] = { 494, 120, 466, 120, -1, -1 };
 const int melody_ERROR_beep[] = { 440, 30, 0, 30, 440, 30, 0, 30, 440, 30, -1, -1 };
+const int melody_tx_timeout_beep[] = { 440, 60, 494, 60, 440, 60, 494, 60, 440, 60, 494, 60, 440, 60, 494, 60, -1, -1 };
 volatile int *melody_play = NULL;
 volatile int melody_idx = 0;
 /*

--- a/firmware/source/menu/menuTxScreen.c
+++ b/firmware/source/menu/menuTxScreen.c
@@ -33,7 +33,7 @@ int menuTxScreen(int buttons, int keys, int events, bool isFirstRun)
 		if (trxCheckFrequencyInAmateurBand(currentChannelData->txFreq))
 		{
 			nextSecondPIT = PITCounter + PIT_COUNTS_PER_SECOND;
-			timeInSeconds=0;
+			timeInSeconds = currentChannelData->tot*15;
 			updateScreen();
 			GPIO_PinWrite(GPIO_LEDgreen, Pin_LEDgreen, 0);
 			GPIO_PinWrite(GPIO_LEDred, Pin_LEDred, 1);
@@ -63,8 +63,25 @@ int menuTxScreen(int buttons, int keys, int events, bool isFirstRun)
 		{
 			if (PITCounter >= nextSecondPIT )
 			{
-				timeInSeconds++;
-				updateScreen();
+				if (currentChannelData->tot==0)
+				{
+					timeInSeconds++;
+				}
+				else
+				{
+					timeInSeconds--;
+				}
+				if (currentChannelData->tot!=0 && timeInSeconds == 0)
+				{
+					set_melody(melody_tx_timeout_beep);
+					UC1701_clearBuf();
+					UC1701_printCentered(20, "TIMEOUT",UC1701_FONT_16x32);
+					UC1701_render();
+				}
+				else
+				{
+					updateScreen();
+				}
 				nextSecondPIT = PITCounter + PIT_COUNTS_PER_SECOND;
 			}
 		}
@@ -87,7 +104,7 @@ static void updateScreen()
 
 static void handleEvent(int buttons, int keys, int events)
 {
-	if ((buttons & BUTTON_PTT)==0)
+	if ((buttons & BUTTON_PTT)==0 || (currentChannelData->tot!=0 && timeInSeconds == 0))
 	{
 		trxIsTransmitting=false;
 		if (txstopdelay>0)

--- a/firmware/source/menu/menuZoneList.c
+++ b/firmware/source/menu/menuZoneList.c
@@ -49,8 +49,12 @@ static void updateScreen()
 	struct_codeplugZone_t zoneBuf;
 	UC1701_clearBuf();
 	UC1701_printCentered(0, "Zones",UC1701_FONT_GD77_8x16);
-	for(int i=-1; i <= 1 ;i++)
+	for(int i=-1; i <= 1;i++)
 	{
+		if (gMenusEndIndex <= (i+1))
+		{
+			break;
+		}
 		rPos= i + gMenusCurrentItemIndex;
 		if (rPos >= gMenusEndIndex)
 		{


### PR DESCRIPTION
Max number of channels per zone should have been 16 instead of 32. This would cause problems if a zone contained the maximum of 16 channels, because the code that counts the number of channels in the zone would count beyond the end of the zone into the next zone.

Also the Zone list screen did not work correctly when there were less than 3 zones, because it assumes a minimum of 3 lines of text (zones) on the screen.

I've made a slight improvement to this, if only 1 or 2 zones exist, only 1 or 2 zones are shown on the screen.

This is not a perfect solution, but its better than before