### PR TITLE
Menu utility header shows now the DMR time slot

### DIFF
--- a/firmware/include/functions/fw_trx.h
+++ b/firmware/include/functions/fw_trx.h
@@ -56,6 +56,7 @@ void trxUpdateC6000Calibration();
 void trxUpdateAT1846SCalibration();
 void trxSetDMRColourCode(int colourCode);
 int trxGetDMRColourCode();
+int trxGetDMRSlot();
 bool trxCheckFrequencyIsVHF(int frequency);
 bool trxCheckFrequencyIsUHF(int frequency);
 bool trxCheckFrequency(int tmp_frequency);

--- a/firmware/source/functions/fw_trx.c
+++ b/firmware/source/functions/fw_trx.c
@@ -508,6 +508,12 @@ int trxGetDMRColourCode()
 	return currentCC;
 }
 
+int trxGetDMRSlot()
+{
+	return ((currentChannelData->flag2 & 0x40) >> 6) + 1;
+}
+
+
 void trxSetTxCTCSS(int toneFreqX10)
 {
 	if (toneFreqX10 == 0xFFFF)

--- a/firmware/source/menu/menuUtilityQSOData.c
+++ b/firmware/source/menu/menuUtilityQSOData.c
@@ -347,8 +347,15 @@ void menuUtilityRenderHeader()
 			break;
 		case RADIO_MODE_DIGITAL:
 			strcpy(buffer, "DMR");
+
+			if(trxGetDMRSlot() == 1)
+				strcat(buffer, " S1");
+			else
+				strcat(buffer, " S2");
 			break;
 	}
+
+
 
 	UC1701_printAt(0,8, buffer,UC1701_FONT_6X8);
 	int  batteryPerentage = (int)(((battery_voltage - CUTOFF_VOLTAGE_UPPER_HYST) * 100) / (BATTERY_MAX_VOLTAGE - CUTOFF_VOLTAGE_UPPER_HYST));


### PR DESCRIPTION
"S1" or "S2" text is appended to "DMR" on the header utility menu